### PR TITLE
Reduce privileges during Reborn, not StartProcess

### DIFF
--- a/daemon_posix.go
+++ b/daemon_posix.go
@@ -109,8 +109,6 @@ func (d *Context) parent() (child *os.Process, err error) {
 		Env:   d.Env,
 		Files: d.files(),
 		Sys: &syscall.SysProcAttr{
-			//Chroot:     d.Chroot,
-			Credential: d.Credential,
 			Setsid:     true,
 		},
 	}
@@ -248,6 +246,16 @@ func (d *Context) child() (err error) {
 	}
 	if len(d.Chroot) > 0 {
 		err = syscall.Chroot(d.Chroot)
+	}
+	if d.Credential.Gid > 0 {
+		if err = syscall.Setgid(int(d.Credential.Gid)); err != nil {
+			return
+		}
+	}
+	if d.Credential.Uid > 0 {
+		if err = syscall.Setuid(int(d.Credential.Uid)); err != nil {
+			return
+		}
 	}
 
 	return


### PR DESCRIPTION
Daemon (child) should be able to run some code with root privileges,
open low ports and logs, for instance.