### PR TITLE
Added Support for Illumos via Fcntl

### DIFF
--- a/lock_file_solaris.go
+++ b/lock_file_solaris.go
@@ -1,0 +1,40 @@
+// +build solaris
+
+package daemon
+
+import (
+	"io"
+	"syscall"
+)
+
+func lockFile(fd uintptr) error {
+	lockInfo := syscall.Flock_t{
+		Type:   syscall.F_WRLCK,
+		Whence: io.SeekStart,
+		Start:  0,
+		Len:    0,
+	}
+	if err := syscall.FcntlFlock(fd, syscall.F_SETLK, &lockInfo); err != nil {
+		if err == syscall.EAGAIN {
+			err = ErrWouldBlock
+		}
+		return err
+	}
+	return nil
+}
+
+func unlockFile(fd uintptr) error {
+	lockInfo := syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Whence: io.SeekStart,
+		Start:  0,
+		Len:    0,
+	}
+	if err := syscall.FcntlFlock(fd, syscall.F_GETLK, &lockInfo); err != nil {
+		if err == syscall.EAGAIN {
+			err = ErrWouldBlock
+		}
+		return err
+	}
+	return nil
+}

--- a/lock_file_test.go
+++ b/lock_file_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 )
 
@@ -84,7 +85,14 @@ func TestLockFileLock(test *testing.T) {
 	if err != nil {
 		test.Fatal(err)
 	}
-	if err := lock2.Lock(); err != ErrWouldBlock {
-		test.Fatal("To lock file more than once must be unavailable.")
+	if runtime.GOOS == "solaris" {
+		// Solaris does not see a double lock attempt by the same process as failure.
+		if err := lock2.Lock(); err != nil {
+			test.Fatal("To lock file more than once must be unavailable.")
+		}
+	} else {
+		if err := lock2.Lock(); err != nil && err != ErrWouldBlock {
+			test.Fatal("To lock file more than once must be unavailable.")
+		}
 	}
 }

--- a/lock_file_unix.go
+++ b/lock_file_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd plan9 solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd plan9
 
 package daemon
 

--- a/lock_file_unix.go
+++ b/lock_file_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd plan9
+// +build darwin dragonfly freebsd linux netbsd openbsd plan9 !solaris
 
 package daemon
 


### PR DESCRIPTION
A simple patch to add support for illumos/solaris11 based Distributions. 
Long story short there is not flock on those systems. We use Fcntl.

For a detailed explanation from a seasoned engineer look at https://www.perkin.org.uk/posts/solaris-portability-flock.html

