### PR TITLE
Use "github.com/kardianos/osext" when Go < 1.8

### DIFF
--- a/daemon_unix.go
+++ b/daemon_unix.go
@@ -170,7 +170,7 @@ func (d *Context) closeFiles() (err error) {
 }
 
 func (d *Context) prepareEnv() (err error) {
-	if d.abspath, err = os.Executable(); err != nil {
+	if d.abspath, err = osExecutable(); err != nil {
 		return
 	}
 

--- a/os_executable.go
+++ b/os_executable.go
@@ -1,0 +1,11 @@
+// +build go1.8
+
+package daemon
+
+import (
+	"os"
+)
+
+func osExecutable() (string, error) {
+	return os.Executable()
+}

--- a/os_executable_pre18.go
+++ b/os_executable_pre18.go
@@ -1,0 +1,11 @@
+// +build !go1.8
+
+package daemon
+
+import (
+	"github.com/kardianos/osext"
+)
+
+func osExecutable() (string, error) {
+	return osext.Executable()
+}


### PR DESCRIPTION
```os.Executable()``` only exists on Go >= 1.8

This change maintains backwards compatibility on platforms that ship orders versions.