### PR TITLE
adapted to nacl (go playground)

### DIFF
--- a/signal.go
+++ b/signal.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"os/signal"
-	"syscall"
 )
 
 // ErrStop should be returned signal handler function
@@ -46,12 +45,6 @@ func ServeSignals() (err error) {
 	}
 
 	return
-}
-
-var handlers = make(map[os.Signal]SignalHandlerFunc)
-
-func init() {
-	handlers[syscall.SIGTERM] = sigtermDefaultHandler
 }
 
 func sigtermDefaultHandler(sig os.Signal) error {

--- a/signal_init.go
+++ b/signal_init.go
@@ -1,0 +1,14 @@
+// +build !nacl
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+var handlers = make(map[os.Signal]SignalHandlerFunc)
+
+func init() {
+	handlers[syscall.SIGTERM] = sigtermDefaultHandler
+}

--- a/signal_init_nacl.go
+++ b/signal_init_nacl.go
@@ -1,0 +1,13 @@
+// +build nacl
+
+package daemon
+
+import (
+	"os"
+)
+
+var handlers = make(map[os.Signal]SignalHandlerFunc)
+
+// func init() {
+// 	handlers[syscall.SIGTERM] = sigtermDefaultHandler
+// }

--- a/syscall_dup.go
+++ b/syscall_dup.go
@@ -1,5 +1,6 @@
 // +build !linux !arm64
 // +build !windows
+// +build !nacl
 // +build go1.7
 
 package daemon

--- a/syscall_dup_nacl.go
+++ b/syscall_dup_nacl.go
@@ -1,0 +1,7 @@
+// +build nacl
+
+package daemon
+
+func syscallDup(oldfd int, newfd int) (err error) {
+	return nil
+}


### PR DESCRIPTION
@sevlyar here is a patch for NaCL and [go playground](https://play.golang.org/).

This patch had been built ok with:

```bash
GOARCH=amd64p32 GOOS=nacl go build examples/cmd/gd-simple/simple.go
for GOOS in windows linux darwin solaris; do go build examples/cmd/gd-simple/simple.go; done
```

**All changes are**:

- split syscall codes from `signal.go` as `signal_init*.go`
- add `syscall_dup_nacl.go`

💃 