### PR TITLE
Remove "darwin/386" pair as it has been obsoleted in Go 1.15

### DIFF
--- a/compilation_test.go
+++ b/compilation_test.go
@@ -18,7 +18,6 @@ func TestCompilation(t *testing.T) {
 	}
 
 	pairs := []string{
-		"darwin/386",
 		"darwin/amd64",
 		"dragonfly/amd64",
 		"freebsd/386",


### PR DESCRIPTION
See https://github.com/golang/go/issues/37610