### PR TITLE
Fix search. Now it will only return a daemon pointer if it is live

### DIFF
--- a/daemon_unix.go
+++ b/daemon_unix.go
@@ -68,6 +68,13 @@ func (d *Context) search() (daemon *os.Process, err error) {
 			return
 		}
 		daemon, err = os.FindProcess(pid)
+		if err == nil && daemon != nil {
+			// Send a test signal to test if this daemon is actually alive or dead
+			// An error means it is dead
+			if daemon.Signal(syscall.Signal(0)) != nil {
+				daemon = nil
+			}
+		}
 	}
 	return
 }


### PR DESCRIPTION
Fix Search of Unix systems. According to the docs for `os.FindProcess(pid)` this will never be nil even when I process doesn't exist.
> On Unix systems, FindProcess always succeeds and returns a Process for the given pid, regardless of whether the process exists. 