### PR TITLE
Add support for riscv64 on Linux

### DIFF
--- a/syscall_dup.go
+++ b/syscall_dup.go
@@ -1,4 +1,5 @@
 // +build !linux !arm64
+// +build !linux !riscv64
 // +build !windows
 // +build go1.7
 

--- a/syscall_dup3.go
+++ b/syscall_dup3.go
@@ -1,4 +1,5 @@
-// +build linux,arm64
+// +build linux
+// +build riscv64 arm64
 
 package daemon
 


### PR DESCRIPTION
Linux on riscv64 doesn't have support for Dup2 syscall,
but as in case with arm64 it defines Dup3 syscall.

 * Rename syscall_dup_arm64 to syscall_dup3
 * Add a conditional compilation comment there to compile it on riscv64 as well

Fixes #74 