### PR TITLE
Fix buildtag for go1.7 introduced in #77

### DIFF
--- a/syscall_dup.go
+++ b/syscall_dup.go
@@ -1,4 +1,4 @@
-//go:build (!linux || !arm64) && (!linux || !riscv64) && !windows && !go1.7
+//go:build (!linux || !arm64) && (!linux || !riscv64) && !windows && go1.7
 // +build !linux !arm64
 // +build !linux !riscv64
 // +build !windows


### PR DESCRIPTION
In #77, `!go1.7` was added to `//go:build` in syscall_dup.go
despite it having `// +build go1.7` tag.

This automatically fixes build on go1.17/FreeBSD, and maybe other
platforms too.