### PR TITLE
fix race condition on writing in wpipe (write |1: broken pipe) (#86)

### DIFF
--- a/daemon_unix.go
+++ b/daemon_unix.go
@@ -110,10 +110,7 @@ func (d *Context) parent() (child *os.Process, err error) {
 
 	d.rpipe.Close()
 	encoder := json.NewEncoder(d.wpipe)
-	if err = encoder.Encode(d); err != nil {
-		return
-	}
-	_, err = fmt.Fprint(d.wpipe, "\n\n")
+	err = encoder.Encode(d)
 	return
 }
 


### PR DESCRIPTION
Patch to the issue: https://github.com/sevlyar/go-daemon/issues/86