### PR TITLE
don't close stdout and stderr 

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -42,3 +42,7 @@ func (d *Context) Search() (daemon *os.Process, err error) {
 func (d *Context) Release() error {
 	return d.release()
 }
+
+func (d *Context) Clean() error {
+	return d.clean()
+}

--- a/daemon_unix.go
+++ b/daemon_unix.go
@@ -173,7 +173,9 @@ func (d *Context) closeFiles() (err error) {
 	}
 	cl(&d.rpipe)
 	cl(&d.wpipe)
-	cl(&d.logFile)
+	if d.logFile != os.Stdout && d.logFile != os.Stderr {
+		cl(&d.logFile)
+	}
 	cl(&d.nullFile)
 	if d.pidFile != nil {
 		d.pidFile.Close()


### PR DESCRIPTION
Closing stdout and stderr will cause the parent and child to be unable to output, and golang cannot reopen stdout and stderr.