### PR TITLE
throw human readable error when pid doesn't exist

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 )
 
@@ -69,12 +70,15 @@ func AddFlag(f Flag, sig os.Signal) {
 
 // SendCommands sends active signals to the given process.
 func SendCommands(p *os.Process) (err error) {
+	if p == nil {
+		return fmt.Errorf("process not found")
+	}
 	for _, sig := range signals() {
 		if err = p.Signal(sig); err != nil {
-			return
+			return fmt.Errorf("failed to send signal %d: %w", sig, err)
 		}
 	}
-	return
+	return nil
 }
 
 // ActiveFlags returns flags that has the state 'set'.

--- a/examples/cmd/gd-signal-handling/signal-handling.go
+++ b/examples/cmd/gd-signal-handling/signal-handling.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"flag"
-	"github.com/sevlyar/go-daemon"
 	"log"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/sevlyar/go-daemon"
 )
 
 var (
@@ -37,7 +38,10 @@ func main() {
 		if err != nil {
 			log.Fatalf("Unable send signal to the daemon: %s", err.Error())
 		}
-		daemon.SendCommands(d)
+		err = daemon.SendCommands(d)
+		if err != nil {
+			log.Fatalln(err.Error())
+		}
 		return
 	}
 


### PR DESCRIPTION
Super simple: signal handling should throw human error when pid doesn't exist

How it looked:

```bash
❯ LOG_LEVEL=dev go run main.go -s stop
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x104fcb87c]

goroutine 1 [running]:
os.(*Process).signal(0x14000151aa8?, {0x105310900?, 0x10521fdd8?})
        /opt/homebrew/Cellar/go/1.21.7/libexec/src/os/exec_unix.go:63 +0x2c
os.(*Process).Signal(...)
        /opt/homebrew/Cellar/go/1.21.7/libexec/src/os/exec.go:140
github.com/sevlyar/go-daemon.SendCommands(0x1c5b?)
        /Users/nathanpierce/go/pkg/mod/github.com/sevlyar/go-daemon@v0.1.6/command.go:73 +0x1a0
main.main()
        /Users/nathanpierce/anklet/main.go:99 +0x79c
exit status 2
```

How it looks now:

```
❯ LOG_LEVEL=dev go run main.go -s stop
2024/04/05 09:39:22 process not found
exit status 1
```
